### PR TITLE
fix: remove 0x prefix from bytecode hex output

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Pass a source file directly to compile it — `edgec` prints the bytecode as a h
 ```sh
 # Compile to EVM bytecode (prints hex to stdout)
 edgec examples/counter.edge
-# 0x60003560e01c8063d09de08a146100365780632baeceb7146100...
+# 60003560e01c8063d09de08a146100365780632baeceb7146100...
 
 # Write raw bytecode bytes to a file
 edgec examples/counter.edge -o counter.bin
@@ -106,7 +106,7 @@ contract Counter {
 
 ```sh
 edgec examples/counter.edge
-# 0x60003560e01c8063d09de08a14610036578063...  (127 bytes)
+# 60003560e01c8063d09de08a14610036578063...  (127 bytes)
 ```
 
 The compiled bytecode includes a selector dispatcher, storage reads/writes via `SLOAD`/`SSTORE`, and a revert fallback for unknown selectors — all verified against a live EVM in the [integration tests](./crates/e2e/).

--- a/bin/edgec/src/cli.rs
+++ b/bin/edgec/src/cli.rs
@@ -193,7 +193,7 @@ impl Cli {
                         eprintln!("warning: empty bytecode produced");
                     } else {
                         let hex: String = bytecode.iter().map(|b| format!("{b:02x}")).collect();
-                        println!("0x{hex}");
+                        println!("{hex}");
 
                         if let Some(path) = output {
                             std::fs::write(&path, bytecode)?;

--- a/crates/codegen/README.md
+++ b/crates/codegen/README.md
@@ -42,7 +42,7 @@ let input = ContractInput {
 };
 
 let bytecode = CodeGenerator::new().generate(&input).unwrap();
-println!("0x{}", hex::encode(&bytecode));
+println!("{}", hex::encode(&bytecode));
 ```
 
 ## Integration

--- a/crates/driver/README.md
+++ b/crates/driver/README.md
@@ -37,7 +37,7 @@ let mut compiler = Compiler::new(config).unwrap();
 let output = compiler.compile().unwrap();
 
 if let Some(bytecode) = output.bytecode {
-    println!("0x{}", hex::encode(&bytecode));
+    println!("{}", hex::encode(&bytecode));
 }
 ```
 


### PR DESCRIPTION
edgec was prefixing its stdout hex output with 0x. The convention among EVM compilers is to emit raw hex without a prefix. Solc does this with --bin, Vyper does the same, and the standard JSON bytecode.object field that Foundry and other downstream tooling consumes must not carry a 0x prefix or it breaks parsing.

This aligns edgec with that convention. The change is a single character removal in the CLI output path, plus updates to the README examples in the root, codegen, and driver crates so the documentation no longer shows the 0x prefix in sample output.

All tests pass.