### PR TITLE
fix: remove dead Stmt::VarAssign and Stmt::ContractImpl AST nodes

### DIFF
--- a/crates/ast/src/item.rs
+++ b/crates/ast/src/item.rs
@@ -143,19 +143,6 @@ pub struct ContractDecl {
     pub span: Span,
 }
 
-/// A contract implementation block
-#[derive(Debug, Clone, PartialEq)]
-pub struct ContractImpl {
-    /// Contract type name
-    pub contract_name: Ident,
-    /// Optional ABI being implemented
-    pub abi_impl: Option<Ident>,
-    /// Contract functions
-    pub functions: Vec<ContractFnDecl>,
-    /// Source span
-    pub span: Span,
-}
-
 /// A function within a contract implementation
 #[derive(Debug, Clone, PartialEq)]
 pub struct ContractFnDecl {

--- a/crates/ast/src/stmt.rs
+++ b/crates/ast/src/stmt.rs
@@ -6,8 +6,8 @@ use edge_types::span::Span;
 
 use crate::{
     item::{
-        AbiDecl, ConstDecl, ContractDecl, ContractImpl, EventDecl, FnDecl, ImplBlock, ModuleDecl,
-        ModuleImport, TraitDecl, TypeDecl,
+        AbiDecl, ConstDecl, ContractDecl, EventDecl, FnDecl, ImplBlock, ModuleDecl, ModuleImport,
+        TraitDecl, TypeDecl,
     },
     pattern::MatchArm,
     Ident,
@@ -64,9 +64,6 @@ pub enum Stmt {
         Span,
     ),
 
-    /// Variable assignment: x = expr
-    VarAssign(crate::Expr, crate::Expr, Span),
-
     /// Type assignment: type X = T
     TypeAssign(TypeDecl, crate::ty::TypeSig, Span),
 
@@ -84,9 +81,6 @@ pub enum Stmt {
 
     /// Contract declaration
     ContractDecl(ContractDecl),
-
-    /// Contract implementation block
-    ContractImpl(ContractImpl),
 
     /// Constant assignment: const x = expr
     ConstAssign(ConstDecl, crate::Expr, Span),
@@ -157,14 +151,12 @@ impl Stmt {
     pub fn span(&self) -> Span {
         match self {
             Self::VarDecl(_, _, _, span) => span.clone(),
-            Self::VarAssign(_, _, span) => span.clone(),
             Self::TypeAssign(_, _, span) => span.clone(),
             Self::TraitDecl(_, span) => span.clone(),
             Self::ImplBlock(item) => item.span.clone(),
             Self::FnAssign(fn_decl, _) => fn_decl.span.clone(),
             Self::AbiDecl(abi) => abi.span.clone(),
             Self::ContractDecl(contract) => contract.span.clone(),
-            Self::ContractImpl(impl_block) => impl_block.span.clone(),
             Self::ConstAssign(_, _, span) => span.clone(),
             Self::ModuleDecl(module) => module.span.clone(),
             Self::ModuleImport(import) => import.span.clone(),

--- a/crates/ir/src/to_egglog/expr.rs
+++ b/crates/ir/src/to_egglog/expr.rs
@@ -80,40 +80,6 @@ impl AstToEgglog {
                 }
             }
 
-            edge_ast::Stmt::VarAssign(lhs, rhs, _span) => {
-                // Clear composite tracking before evaluating RHS
-                self.last_composite_alloc = None;
-                // Set type hint from the LHS variable's declared type
-                if let edge_ast::Expr::Ident(ident) = lhs {
-                    for scope in self.scopes.iter().rev() {
-                        if let Some(binding) = scope.bindings.get(&ident.name) {
-                            self.type_hint = Some(binding._ty.clone());
-                            break;
-                        }
-                    }
-                }
-                let rhs_ir = self.lower_expr(rhs)?;
-                self.type_hint = None;
-                // If RHS was a struct/array instantiation, wire composite info to LHS binding
-                // (skip storage fields — they already have composite_type set from lower_contract)
-                let rhs_composite = self.last_composite_alloc.clone();
-                if let Some((ref type_name, base)) = rhs_composite {
-                    if let edge_ast::Expr::Ident(ident) = lhs {
-                        for scope in self.scopes.iter_mut().rev() {
-                            if let Some(binding) = scope.bindings.get_mut(&ident.name) {
-                                if binding.storage_slot.is_none() {
-                                    binding.composite_type = Some(type_name.clone());
-                                    binding.composite_base = Some(base);
-                                }
-                                break;
-                            }
-                        }
-                    }
-                }
-                self.last_composite_alloc = None;
-                self.lower_assignment_with_composite(lhs, rhs_ir, rhs_composite.as_ref())
-            }
-
             edge_ast::Stmt::ConstAssign(const_decl, expr, _span) => {
                 let val = self.lower_expr(expr)?;
                 let ty = const_decl


### PR DESCRIPTION
Fixes #51.

Stmt::VarAssign was defined in crates/ast/src/stmt.rs but never constructed by the parser. All assignments reach the compiler as Stmt::Expr(Expr::Assign(...)), making VarAssign permanently unreachable in every match across the compiler passes. The associated handler in crates/ir/src/to_egglog/expr.rs was similarly dead.

Stmt::ContractImpl and its ContractImpl struct in crates/ast/src/item.rs had the same problem: the variant existed in the enum and the struct was fully defined, but no parse path ever produced one. It appeared in no lowering, typechecking, or codegen code outside its own definition file.

Both dead constructs have been removed. The workspace compiles cleanly, all tests pass, and all example files continue to parse correctly.